### PR TITLE
Potential Vulnerability in Cloned Code (CVE-2015-9251: jQuery cross-domain ajaxConvert)

### DIFF
--- a/static/admin/js/vendor/jquery/jquery.js
+++ b/static/admin/js/vendor/jquery/jquery.js
@@ -8746,6 +8746,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
## Summary

Patches the vendored Django admin jQuery copy at `static/admin/js/vendor/jquery/jquery.js` (jQuery 3.3.1) to align with upstream jQuery mitigation for **CVE-2015-9251** / **gh-2432**: cross-domain Ajax responses must not be converted to inferred `script` dataType in a way that enables script execution.

## Changes

In `ajaxConvert`, skip conversion to `script` when `s.crossDomain` is true, mirroring [jQuery commit 2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49). Explicit `dataType: "script"` on same-origin requests is unaffected by this guard in the same way as upstream.

## Impact

Reduces XSS risk for consumers of this bundled file in the admin UI when cross-domain `$.ajax` is used with inferred script handling.

## References

- [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
- [jQuery gh-2432](https://github.com/jquery/jquery/issues/2432)
- Upstream fix: https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49